### PR TITLE
feat: 가게 단건 조회 보완 및 가게 검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	compileOnly 'org.projectlombok:lombok'
 	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/mini/delivery/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/mini/delivery/domain/menu/repository/MenuRepository.java
@@ -4,6 +4,10 @@ import mini.delivery.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    List<Menu> findAllByStoreId(Long storeId);
 }

--- a/src/main/java/mini/delivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/mini/delivery/domain/review/repository/ReviewRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT AVG(r.rating) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
-    float averageRatingByStoreId(@Param("storeId") Long storeId);
+    double averageRatingByStoreId(@Param("storeId") Long storeId);
 
     @Query("SELECT COUNT(r.id) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
     long countByStoreId(@Param("storeId") Long storeId);

--- a/src/main/java/mini/delivery/domain/store/controller/StoreController.java
+++ b/src/main/java/mini/delivery/domain/store/controller/StoreController.java
@@ -2,10 +2,7 @@ package mini.delivery.domain.store.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import mini.delivery.domain.store.dto.StoreCreateRequestDto;
-import mini.delivery.domain.store.dto.StoreCreateResponseDto;
-import mini.delivery.domain.store.dto.StoreResponseDto;
-import mini.delivery.domain.store.dto.StoreUpdateRequestDto;
+import mini.delivery.domain.store.dto.*;
 import mini.delivery.domain.store.service.StoreService;
 import mini.delivery.global.auth.UserDetailsImpl;
 import mini.delivery.global.common.dto.CommonResponseBody;
@@ -13,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -56,5 +55,14 @@ public class StoreController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(CommonResponseBody.success("가게 조회를 성공하였습니다.", storeResponseDto));
+    }
+
+    @GetMapping("/stores")
+    public ResponseEntity<CommonResponseBody<List<StoreSummaryResponseDto>>> searchStores(@RequestParam(value = "keyword", required = false) String keyword) {
+        List<StoreSummaryResponseDto> storeSummaryResponseDtoList = storeService.searchStores(keyword);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponseBody.success("가게 목록 조회를 성공하였습니다.", storeSummaryResponseDtoList));
     }
 }

--- a/src/main/java/mini/delivery/domain/store/dto/StoreMenuResponseDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/StoreMenuResponseDto.java
@@ -1,0 +1,28 @@
+package mini.delivery.domain.store.dto;
+
+import lombok.Getter;
+import mini.delivery.domain.menu.entity.Menu;
+
+import java.util.List;
+
+@Getter
+public class StoreMenuResponseDto {
+
+    private final String menuName;
+    private final int price;
+
+    private StoreMenuResponseDto(String menuName, int price) {
+        this.menuName = menuName;
+        this.price = price;
+    }
+
+    public static StoreMenuResponseDto from(Menu menu) {
+        return new StoreMenuResponseDto(menu.getName(), menu.getPrice());
+    }
+
+    public static List<StoreMenuResponseDto> from(List<Menu> menus) {
+        return menus.stream()
+                .map(StoreMenuResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/mini/delivery/domain/store/dto/StoreResponseDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/StoreResponseDto.java
@@ -5,12 +5,13 @@ import mini.delivery.domain.store.entity.Store;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 public class StoreResponseDto {
 
     private final Long id;
-    private final String name;
+    private final String storeName;
     private final String address;
     private final int minOrderAmount;
     private final LocalTime openTime;
@@ -19,10 +20,11 @@ public class StoreResponseDto {
     private final float averageRating;
     private final long reviewCount;
     private final LocalDateTime createdAt;
+    private final List<StoreMenuResponseDto> menus;
 
-    private StoreResponseDto(Long id, String name, String address, int minOrderAmount, LocalTime openTime, LocalTime closeTime, String storeStatus, float averageRating, long reviewCount, LocalDateTime createdAt) {
+    private StoreResponseDto(Long id, String storeName, String address, int minOrderAmount, LocalTime openTime, LocalTime closeTime, String storeStatus, float averageRating, long reviewCount, LocalDateTime createdAt, List<StoreMenuResponseDto> menus) {
         this.id = id;
-        this.name = name;
+        this.storeName = storeName;
         this.address = address;
         this.minOrderAmount = minOrderAmount;
         this.openTime = openTime;
@@ -31,9 +33,10 @@ public class StoreResponseDto {
         this.averageRating = averageRating;
         this.reviewCount = reviewCount;
         this.createdAt = createdAt;
+        this.menus = menus;
     }
 
-    public static StoreResponseDto from(Store store, float averageRating, long reviewCount) {
+    public static StoreResponseDto from(Store store, float averageRating, long reviewCount, List<StoreMenuResponseDto> menus) {
         return new StoreResponseDto(
                 store.getId(),
                 store.getName(),
@@ -44,7 +47,8 @@ public class StoreResponseDto {
                 store.getStoreStatus().name(),
                 averageRating,
                 reviewCount,
-                store.getCreatedAt()
+                store.getCreatedAt(),
+                menus
         );
     }
 }

--- a/src/main/java/mini/delivery/domain/store/dto/StoreResponseDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/StoreResponseDto.java
@@ -17,12 +17,12 @@ public class StoreResponseDto {
     private final LocalTime openTime;
     private final LocalTime closeTime;
     private final String storeStatus;
-    private final float averageRating;
+    private final double averageRating;
     private final long reviewCount;
     private final LocalDateTime createdAt;
     private final List<StoreMenuResponseDto> menus;
 
-    private StoreResponseDto(Long id, String storeName, String address, int minOrderAmount, LocalTime openTime, LocalTime closeTime, String storeStatus, float averageRating, long reviewCount, LocalDateTime createdAt, List<StoreMenuResponseDto> menus) {
+    private StoreResponseDto(Long id, String storeName, String address, int minOrderAmount, LocalTime openTime, LocalTime closeTime, String storeStatus, double averageRating, long reviewCount, LocalDateTime createdAt, List<StoreMenuResponseDto> menus) {
         this.id = id;
         this.storeName = storeName;
         this.address = address;
@@ -36,7 +36,7 @@ public class StoreResponseDto {
         this.menus = menus;
     }
 
-    public static StoreResponseDto from(Store store, float averageRating, long reviewCount, List<StoreMenuResponseDto> menus) {
+    public static StoreResponseDto from(Store store, double averageRating, long reviewCount, List<StoreMenuResponseDto> menus) {
         return new StoreResponseDto(
                 store.getId(),
                 store.getName(),

--- a/src/main/java/mini/delivery/domain/store/dto/StoreSummaryDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/StoreSummaryDto.java
@@ -1,0 +1,23 @@
+package mini.delivery.domain.store.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class StoreSummaryDto {
+
+    private final Long id;
+    private final String name;
+    private final int minOrderAmount;
+    private final double averageRating;
+    private final long reviewCount;
+
+    @QueryProjection
+    public StoreSummaryDto(Long id, String name, int minOrderAmount, double averageRating, long reviewCount) {
+        this.id = id;
+        this.name = name;
+        this.minOrderAmount = minOrderAmount;
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
+    }
+}

--- a/src/main/java/mini/delivery/domain/store/dto/StoreSummaryResponseDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/StoreSummaryResponseDto.java
@@ -1,0 +1,39 @@
+package mini.delivery.domain.store.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StoreSummaryResponseDto {
+
+    private final Long id;
+    private final String name;
+    private final int minOrderAmount;
+    private final double averageRating;
+    private final long reviewCount;
+
+    private StoreSummaryResponseDto(Long id, String name, int minOrderAmount, double averageRating, long reviewCount) {
+        this.id = id;
+        this.name = name;
+        this.minOrderAmount = minOrderAmount;
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
+    }
+
+    public static StoreSummaryResponseDto from(StoreSummaryDto storeSummaryDto) {
+        return new StoreSummaryResponseDto(
+                storeSummaryDto.getId(),
+                storeSummaryDto.getName(),
+                storeSummaryDto.getMinOrderAmount(),
+                storeSummaryDto.getAverageRating(),
+                storeSummaryDto.getReviewCount()
+        );
+    }
+
+    public static List<StoreSummaryResponseDto> from(List<StoreSummaryDto> storeSummaryDtoList) {
+        return storeSummaryDtoList.stream()
+                .map(StoreSummaryResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/mini/delivery/domain/store/repository/CustomStoreRepository.java
+++ b/src/main/java/mini/delivery/domain/store/repository/CustomStoreRepository.java
@@ -1,0 +1,10 @@
+package mini.delivery.domain.store.repository;
+
+import mini.delivery.domain.store.dto.StoreSummaryDto;
+
+import java.util.List;
+
+public interface CustomStoreRepository {
+
+    List<StoreSummaryDto> searchStores(String keyword);
+}

--- a/src/main/java/mini/delivery/domain/store/repository/CustomStoreRepositoryImpl.java
+++ b/src/main/java/mini/delivery/domain/store/repository/CustomStoreRepositoryImpl.java
@@ -1,0 +1,51 @@
+package mini.delivery.domain.store.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.menu.entity.QMenu;
+import mini.delivery.domain.order.entity.QOrder;
+import mini.delivery.domain.review.entity.QReview;
+import mini.delivery.domain.store.dto.QStoreSummaryDto;
+import mini.delivery.domain.store.dto.StoreSummaryDto;
+import mini.delivery.domain.store.entity.QStore;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomStoreRepositoryImpl implements CustomStoreRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<StoreSummaryDto> searchStores(String keyword) {
+        QStore store = QStore.store;
+        QReview review = QReview.review;
+        QOrder order = QOrder.order;
+        QMenu menu = QMenu.menu;
+
+        BooleanBuilder conditions = new BooleanBuilder();
+        conditions.and(store.isDeleted.eq(false));
+
+        if (keyword != null) {
+            conditions.and(store.name.contains(keyword))
+                    .or(menu.name.contains(keyword));
+        }
+
+        return jpaQueryFactory.select(new QStoreSummaryDto(
+                        store.id,
+                        store.name,
+                        store.minOrderAmount,
+                        review.rating.avg(),
+                        review.id.countDistinct()
+                ))
+                .from(store)
+                .leftJoin(order).on(store.id.eq(order.store.id))
+                .leftJoin(review).on(order.id.eq(review.order.id).and(review.isDeleted.eq(false)))
+                .leftJoin(menu).on(store.id.eq(menu.store.id))
+                .where(conditions)
+                .groupBy(store.id)
+                .orderBy(review.rating.avg().desc(), review.id.countDistinct().desc(), store.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/mini/delivery/domain/store/repository/StoreRepository.java
+++ b/src/main/java/mini/delivery/domain/store/repository/StoreRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, CustomStoreRepository {
 
     long countByUserId(Long userId);
 

--- a/src/main/java/mini/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/mini/delivery/domain/store/service/StoreService.java
@@ -64,7 +64,7 @@ public class StoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
 
-        float averageRating = reviewRepository.averageRatingByStoreId(storeId);
+        double averageRating = reviewRepository.averageRatingByStoreId(storeId);
         long reviewCount = reviewRepository.countByStoreId(storeId);
 
         List<Menu> menus = menuRepository.findAllByStoreId(storeId);

--- a/src/main/java/mini/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/mini/delivery/domain/store/service/StoreService.java
@@ -72,6 +72,13 @@ public class StoreService {
         return StoreResponseDto.from(store, averageRating, reviewCount, StoreMenuResponseDto.from(menus));
     }
 
+    @Transactional(readOnly = true)
+    public List<StoreSummaryResponseDto> searchStores(String keyword) {
+        List<StoreSummaryDto> stores = storeRepository.searchStores(keyword);
+
+        return StoreSummaryResponseDto.from(stores);
+    }
+
     private void validateStoreLimit(Long userId) {
         long storeCount = storeRepository.countByUserId(userId);
         if (storeCount >= 3) {

--- a/src/main/java/mini/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/mini/delivery/domain/store/service/StoreService.java
@@ -1,11 +1,10 @@
 package mini.delivery.domain.store.service;
 
 import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.menu.entity.Menu;
+import mini.delivery.domain.menu.repository.MenuRepository;
 import mini.delivery.domain.review.repository.ReviewRepository;
-import mini.delivery.domain.store.dto.StoreCreateRequestDto;
-import mini.delivery.domain.store.dto.StoreCreateResponseDto;
-import mini.delivery.domain.store.dto.StoreResponseDto;
-import mini.delivery.domain.store.dto.StoreUpdateRequestDto;
+import mini.delivery.domain.store.dto.*;
 import mini.delivery.domain.store.entity.Store;
 import mini.delivery.domain.store.repository.StoreRepository;
 import mini.delivery.domain.user.entity.User;
@@ -15,6 +14,8 @@ import mini.delivery.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class StoreService {
@@ -22,6 +23,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
     private final ReviewRepository reviewRepository;
+    private final MenuRepository menuRepository;
 
     @Transactional
     public StoreCreateResponseDto createStore(StoreCreateRequestDto storeCreateRequestDto, String email) {
@@ -61,10 +63,13 @@ public class StoreService {
     public StoreResponseDto getStoreById(Long storeId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
         float averageRating = reviewRepository.averageRatingByStoreId(storeId);
         long reviewCount = reviewRepository.countByStoreId(storeId);
 
-        return StoreResponseDto.from(store, averageRating, reviewCount);
+        List<Menu> menus = menuRepository.findAllByStoreId(storeId);
+
+        return StoreResponseDto.from(store, averageRating, reviewCount, StoreMenuResponseDto.from(menus));
     }
 
     private void validateStoreLimit(Long userId) {

--- a/src/main/java/mini/delivery/global/config/QuerydslConfig.java
+++ b/src/main/java/mini/delivery/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package mini.delivery.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 구현
- 가게 단건 조회 Response DTO에 메뉴 목록 추가
- 가게 검색 기능 구현

## 의존성 추가
- QueryDSL 의존성 추가

## 개선
- 리뷰 평균 별점 타입 변경 (float → double)

## 참고
- https://velog.io/@mooh2jj/JAVA-double%EC%99%80-float%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90