### PR TITLE
feat: 장바구니 아이템 추가 API 구현

### DIFF
--- a/src/main/java/mini/delivery/domain/cart/controller/CartController.java
+++ b/src/main/java/mini/delivery/domain/cart/controller/CartController.java
@@ -1,0 +1,37 @@
+package mini.delivery.domain.cart.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.cart.dto.CartItemCreateRequestDto;
+import mini.delivery.domain.cart.service.CartService;
+import mini.delivery.global.auth.UserDetailsImpl;
+import mini.delivery.global.common.dto.CommonResponseBody;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/items")
+    public ResponseEntity<CommonResponseBody<Void>> addCartItem(@Valid @RequestBody CartItemCreateRequestDto cartItemCreateRequestDto,
+                                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        cartService.addCartItem(
+                cartItemCreateRequestDto.getMenuId(),
+                cartItemCreateRequestDto.getQuantity(),
+                userDetails.getUsername()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommonResponseBody.success("장바구니에 담았습니다."));
+    }
+}

--- a/src/main/java/mini/delivery/domain/cart/dto/CartItemCreateRequestDto.java
+++ b/src/main/java/mini/delivery/domain/cart/dto/CartItemCreateRequestDto.java
@@ -1,0 +1,18 @@
+package mini.delivery.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CartItemCreateRequestDto {
+
+    @NotNull
+    private final Long menuId;
+
+    @NotNull
+    @Min(value = 1)
+    private final int quantity;
+}

--- a/src/main/java/mini/delivery/domain/cart/entity/Cart.java
+++ b/src/main/java/mini/delivery/domain/cart/entity/Cart.java
@@ -26,7 +26,7 @@ public class Cart extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id", nullable = false, updatable = false)
+    @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -39,5 +39,9 @@ public class Cart extends BaseEntity {
 
     public static Cart create(User user, Store store) {
         return new Cart(user, store);
+    }
+
+    public void updateCart(Store newStore) {
+        this.store = newStore;
     }
 }

--- a/src/main/java/mini/delivery/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/mini/delivery/domain/cart/repository/CartItemRepository.java
@@ -1,9 +1,16 @@
 package mini.delivery.domain.cart.repository;
 
+import mini.delivery.domain.cart.entity.Cart;
 import mini.delivery.domain.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    Optional<CartItem> findByCartAndMenuId(Cart cart, Long menuId);
+
+    void deleteAllByCart(Cart cart);
 }

--- a/src/main/java/mini/delivery/domain/cart/repository/CartRepository.java
+++ b/src/main/java/mini/delivery/domain/cart/repository/CartRepository.java
@@ -4,6 +4,10 @@ import mini.delivery.domain.cart.entity.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByUserId(Long userId);
 }

--- a/src/main/java/mini/delivery/domain/cart/service/CartService.java
+++ b/src/main/java/mini/delivery/domain/cart/service/CartService.java
@@ -1,0 +1,66 @@
+package mini.delivery.domain.cart.service;
+
+import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.cart.entity.Cart;
+import mini.delivery.domain.cart.entity.CartItem;
+import mini.delivery.domain.cart.repository.CartItemRepository;
+import mini.delivery.domain.cart.repository.CartRepository;
+import mini.delivery.domain.menu.entity.Menu;
+import mini.delivery.domain.menu.repository.MenuRepository;
+import mini.delivery.domain.store.entity.Store;
+import mini.delivery.domain.user.entity.User;
+import mini.delivery.domain.user.repository.UserRepository;
+import mini.delivery.global.error.CustomException;
+import mini.delivery.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+
+    /**
+     * 1. 장바구니를 조회하고 없으면 생성 (orElseGet)
+     * 2. 다른 가게 메뉴를 담을 경우, 장바구니에 담긴 기존 메뉴 삭제 (가게 비교)
+     * 3. 동일한 메뉴 추가 불가
+     * 4. CartItem 저장
+     */
+    @Transactional
+    public void addCartItem(Long menuId, int quantity, String email) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Menu menu = menuRepository.findByIdWithStore(menuId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        Cart cart = cartRepository.findByUserId(user.getId())
+                .orElseGet(() -> cartRepository.save(Cart.create(user, menu.getStore())));
+
+        clearCartIfDifferentStore(cart, menu.getStore());
+        validateDuplicateMenu(cart, menuId);
+
+        CartItem cartItem = CartItem.create(cart, menu, quantity);
+        cartItemRepository.save(cartItem);
+    }
+
+    private void clearCartIfDifferentStore(Cart cart, Store newStore) {
+        Long currentStoreId = cart.getStore().getId();
+        Long newStoreId = newStore.getId();
+
+        if (!currentStoreId.equals(newStoreId)) {
+            cartItemRepository.deleteAllByCart(cart);
+            cart.updateCart(newStore);
+        }
+    }
+
+    private void validateDuplicateMenu(Cart cart, Long menuId) {
+        cartItemRepository.findByCartAndMenuId(cart, menuId)
+                .ifPresent(item -> {
+                    throw new CustomException(ErrorCode.CART_ITEM_ALREADY_EXISTS);
+                });
+    }
+}

--- a/src/main/java/mini/delivery/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/mini/delivery/domain/menu/repository/MenuRepository.java
@@ -2,12 +2,18 @@ package mini.delivery.domain.menu.repository;
 
 import mini.delivery.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     List<Menu> findAllByStoreId(Long storeId);
+
+    @Query("SELECT m FROM Menu m INNER JOIN FETCH m.store WHERE m.id = :id")
+    Optional<Menu> findByIdWithStore(@Param("id") Long menuId);
 }

--- a/src/main/java/mini/delivery/global/error/ErrorCode.java
+++ b/src/main/java/mini/delivery/global/error/ErrorCode.java
@@ -14,10 +14,12 @@ public enum ErrorCode {
     // 404 NOT_FOUND
     USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
     STORE_NOT_FOUND(NOT_FOUND, "가게를 찾을 수 없습니다."),
+    MENU_NOT_FOUND(NOT_FOUND, "가게를 찾을 수 없습니다."),
 
     // 409 CONFLICT
     EMAIL_ALREADY_EXISTS(CONFLICT, "이미 사용 중인 이메일입니다."),
-    STORE_LIMIT_EXCEEDED(CONFLICT, "가게는 최대 3개까지 운영할 수 있습니다.");
+    STORE_LIMIT_EXCEEDED(CONFLICT, "가게는 최대 3개까지 운영할 수 있습니다."),
+    CART_ITEM_ALREADY_EXISTS(CONFLICT, "이미 장바구니에 담긴 메뉴입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
- 사용자 장바구니 조회 및 없을 경우 생성
- 다른 가게 메뉴 추가 시 기존 아이템 삭제
- 동일 메뉴 중복 추가 방지
- CartItem 저장 로직 구현