### PR TITLE
fix: 메뉴 삭제 시 storeId 소속 검증 추

### DIFF
--- a/src/main/java/mini/delivery/domain/menu/service/MenuService.java
+++ b/src/main/java/mini/delivery/domain/menu/service/MenuService.java
@@ -77,7 +77,9 @@ public class MenuService {
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
         Menu menu = menuRepository.findByIdWithStore(menuId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
-
+        if(!menu.getStore().getId().equals(storeId)){
+            throw new CustomException(ErrorCode.MENU_NOT_FOUND);
+        }
         menu.deleteMenu();
     }
 }


### PR DESCRIPTION
- MenuService.deleteMenu에서 menu.storeId와 요청 storeId 불일치 시 예외 처리