### PR TITLE
feat: 주문 상태 변경 API 구현 및 검증 로직 추가

### DIFF
--- a/src/main/java/mini/delivery/domain/order/controller/OwnerOrderController.java
+++ b/src/main/java/mini/delivery/domain/order/controller/OwnerOrderController.java
@@ -1,0 +1,37 @@
+package mini.delivery.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.order.dto.OrderStatusUpdateRequestDto;
+import mini.delivery.domain.order.dto.OrderStatusUpdateResponseDto;
+import mini.delivery.domain.order.service.OwnerOrderService;
+import mini.delivery.global.auth.UserDetailsImpl;
+import mini.delivery.global.common.dto.CommonResponseBody;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/owner/stores/{storeId}/orders")
+@RequiredArgsConstructor
+public class OwnerOrderController {
+
+    private final OwnerOrderService ownerOrderService;
+
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<CommonResponseBody<OrderStatusUpdateResponseDto>> updateOrderStatus(@PathVariable Long storeId,
+                                                                                              @PathVariable Long orderId,
+                                                                                              @RequestBody OrderStatusUpdateRequestDto orderStatusUpdateRequestDto,
+                                                                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        OrderStatusUpdateResponseDto orderStatusUpdateResponseDto = ownerOrderService.updateOrderStatus(
+                storeId,
+                orderId,
+                orderStatusUpdateRequestDto.getOrderStatus(),
+                userDetails.getUsername()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponseBody.success("주문 상태를 변경하였습니다.", orderStatusUpdateResponseDto));
+    }
+}

--- a/src/main/java/mini/delivery/domain/order/dto/OrderStatusUpdateRequestDto.java
+++ b/src/main/java/mini/delivery/domain/order/dto/OrderStatusUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package mini.delivery.domain.order.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OrderStatusUpdateRequestDto {
+
+    private final String orderStatus;
+}

--- a/src/main/java/mini/delivery/domain/order/dto/OrderStatusUpdateResponseDto.java
+++ b/src/main/java/mini/delivery/domain/order/dto/OrderStatusUpdateResponseDto.java
@@ -1,0 +1,23 @@
+package mini.delivery.domain.order.dto;
+
+import lombok.Getter;
+import mini.delivery.domain.order.entity.Order;
+
+@Getter
+public class OrderStatusUpdateResponseDto {
+
+    private final Long orderId;
+    private final String orderStatus;
+
+    private OrderStatusUpdateResponseDto(Long orderId, String orderStatus) {
+        this.orderId = orderId;
+        this.orderStatus = orderStatus;
+    }
+
+    public static OrderStatusUpdateResponseDto from(Order order) {
+        return new OrderStatusUpdateResponseDto(
+                order.getId(),
+                order.getOrderStatus().name()
+        );
+    }
+}

--- a/src/main/java/mini/delivery/domain/order/entity/Order.java
+++ b/src/main/java/mini/delivery/domain/order/entity/Order.java
@@ -71,4 +71,12 @@ public class Order extends BaseEntity {
                 .orderStatus(OrderStatus.PENDING)
                 .build();
     }
+
+    public boolean isPendingStatus() {
+        return orderStatus.equals(OrderStatus.PENDING);
+    }
+
+    public boolean isNotPendingStatus() {
+        return !isPendingStatus();
+    }
 }

--- a/src/main/java/mini/delivery/domain/order/entity/Order.java
+++ b/src/main/java/mini/delivery/domain/order/entity/Order.java
@@ -79,4 +79,8 @@ public class Order extends BaseEntity {
     public boolean isNotPendingStatus() {
         return !isPendingStatus();
     }
+
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/mini/delivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/mini/delivery/domain/order/repository/OrderRepository.java
@@ -2,6 +2,8 @@ package mini.delivery.domain.order.repository;
 
 import mini.delivery.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,11 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByIdAndUserId(Long orderId, Long userId);
+
+    @Query("SELECT o FROM Order o INNER JOIN o.store s WHERE o.id = :id AND s.id = :storeId AND s.user.id = :userId")
+    Optional<Order> findByIdAndStoreIdAndOwnerId(
+            @Param("id") Long orderId,
+            @Param("storeId") Long storeId,
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/mini/delivery/domain/order/service/CustomerOrderService.java
+++ b/src/main/java/mini/delivery/domain/order/service/CustomerOrderService.java
@@ -67,6 +67,7 @@ public class CustomerOrderService {
         Order order = orderRepository.findByIdAndUserId(orderId, user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
+        validatePendingStatus(order);
         orderRepository.delete(order);
     }
 
@@ -84,5 +85,11 @@ public class CustomerOrderService {
 
     private void clearCartItem(Cart cart) {
         cartItemRepository.deleteAllByCart(cart);
+    }
+
+    private void validatePendingStatus(Order order) {
+        if (order.isNotPendingStatus()) {
+            throw new CustomException(ErrorCode.ORDER_NOT_IN_PENDING_STATUS);
+        }
     }
 }

--- a/src/main/java/mini/delivery/domain/order/service/CustomerOrderService.java
+++ b/src/main/java/mini/delivery/domain/order/service/CustomerOrderService.java
@@ -41,6 +41,8 @@ public class CustomerOrderService {
         validateStoreOpen(cart.getStore());
 
         List<CartItem> cartItems = cartItemRepository.findAllByCartIdWithMenu(cart.getId());
+        validateCartNotEmpty(cartItems);
+
         int totalAmount = calculateTotalAmount(cartItems);
 
         Order order = Order.create(user, cart.getStore(), address, totalAmount);
@@ -74,6 +76,12 @@ public class CustomerOrderService {
     private void validateStoreOpen(Store store) {
         if (store.isNotOpenStatus()) {
             throw new CustomException(ErrorCode.STORE_NOT_OPEN);
+        }
+    }
+
+    private void validateCartNotEmpty(List<CartItem> cartItems) {
+        if (cartItems.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_ITEM_NOT_FOUND);
         }
     }
 

--- a/src/main/java/mini/delivery/domain/order/service/OwnerOrderService.java
+++ b/src/main/java/mini/delivery/domain/order/service/OwnerOrderService.java
@@ -1,0 +1,43 @@
+package mini.delivery.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import mini.delivery.domain.order.dto.OrderStatusUpdateResponseDto;
+import mini.delivery.domain.order.entity.Order;
+import mini.delivery.domain.order.repository.OrderRepository;
+import mini.delivery.domain.user.entity.User;
+import mini.delivery.domain.user.repository.UserRepository;
+import mini.delivery.global.common.enums.OrderStatus;
+import mini.delivery.global.error.CustomException;
+import mini.delivery.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerOrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public OrderStatusUpdateResponseDto updateOrderStatus(Long storeId, Long orderId, String orderStatus, String email) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Order order = orderRepository.findByIdAndStoreIdAndOwnerId(orderId, storeId, user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus targetStatus = OrderStatus.of(orderStatus);
+        validateOrderStatus(order, targetStatus);
+        order.updateOrderStatus(targetStatus);
+
+        return OrderStatusUpdateResponseDto.from(order);
+    }
+
+    // 현재 주문 상태에서 요청한 상태로 변경 가능한지 검증
+    private void validateOrderStatus(Order order, OrderStatus targetStatus) {
+        OrderStatus currentStatus = order.getOrderStatus();
+        if (!currentStatus.canChangeTo(targetStatus)) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS_TRANSITION);
+        }
+    }
+}

--- a/src/main/java/mini/delivery/global/common/enums/OrderStatus.java
+++ b/src/main/java/mini/delivery/global/common/enums/OrderStatus.java
@@ -22,4 +22,13 @@ public enum OrderStatus {
 
         throw new IllegalArgumentException("해당하는 이름의 상태를 찾을 수 없습니다: " + status);
     }
+
+    public boolean canChangeTo(OrderStatus targetStatus) {
+        return switch (this) {
+            case PENDING -> targetStatus == COOKING;
+            case COOKING -> targetStatus == DELIVERING;
+            case DELIVERING -> targetStatus == DELIVERED;
+            case DELIVERED -> false;
+        };
+    }
 }

--- a/src/main/java/mini/delivery/global/error/ErrorCode.java
+++ b/src/main/java/mini/delivery/global/error/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // 400 BAD_REQUEST
     PASSWORD_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     STORE_NOT_OPEN(BAD_REQUEST, "영업 중이 아닙니다."),
+    ORDER_NOT_IN_PENDING_STATUS(BAD_REQUEST, "주문 확인 상태가 아닙니다."),
 
     // 404 NOT_FOUND
     USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/mini/delivery/global/error/ErrorCode.java
+++ b/src/main/java/mini/delivery/global/error/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     STORE_NOT_OPEN(BAD_REQUEST, "영업 중이 아닙니다."),
     ORDER_NOT_IN_PENDING_STATUS(BAD_REQUEST, "주문 확인 상태가 아닙니다."),
+    ORDER_INVALID_STATUS_TRANSITION(BAD_REQUEST, "현재 주문 상태에서는 요청한 상태로 변경할 수 없습니다."),
 
     // 404 NOT_FOUND
     USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),


### PR DESCRIPTION
- 주문 상태 변경 기능 구현
- 주문 확인 상태일 때만 주문 취소 가능
- 주문 시 장바구니에 담긴 메뉴가 없으면 주문 불가