### PR TITLE
feat: 점주 가게 목록 API

### DIFF
--- a/src/main/java/mini/delivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/mini/delivery/domain/review/repository/ReviewRepository.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
+    @Query("SELECT COALESCE(AVG(r.rating), 0) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
     double averageRatingByStoreId(@Param("storeId") Long storeId);
 
-    @Query("SELECT COUNT(r.id) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
+    @Query("SELECT COALESCE(COUNT(r.id), 0) FROM Review r WHERE r.isDeleted = false AND r.order.store.id = :storeId")
     long countByStoreId(@Param("storeId") Long storeId);
 }

--- a/src/main/java/mini/delivery/domain/store/controller/StoreController.java
+++ b/src/main/java/mini/delivery/domain/store/controller/StoreController.java
@@ -93,4 +93,15 @@ public class StoreController {
 
         return ResponseEntity.noContent().build();
     }
+
+    // 가게 다건 조회
+    @GetMapping("/owner/stores")
+    public ResponseEntity<CommonResponseBody<List<OwnerStoreResponseDto>>> allFindStore(@AuthenticationPrincipal UserDetailsImpl userDetails){
+
+        List<OwnerStoreResponseDto> ownerStoreResponseDtoList = storeService.allFindStore(
+                userDetails.getUsername()
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(CommonResponseBody.success("가게 다건 조회를 성공 하였습니다.",ownerStoreResponseDtoList));
+    }
 }

--- a/src/main/java/mini/delivery/domain/store/dto/OwnerStoreResponseDto.java
+++ b/src/main/java/mini/delivery/domain/store/dto/OwnerStoreResponseDto.java
@@ -1,0 +1,40 @@
+package mini.delivery.domain.store.dto;
+
+import lombok.Getter;
+import mini.delivery.domain.store.entity.Store;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class OwnerStoreResponseDto {
+
+    private final Long id;
+    private final String name;
+    private final double averageRating;
+    private final Long reviewCount;
+    private final String storeStatus;
+    private final boolean deleted;
+    private final LocalDateTime createdAt;
+
+    private OwnerStoreResponseDto(Long id, String name, double averageRating, Long reviewCount, String storeStatus, boolean deleted, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
+        this.storeStatus = storeStatus;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+    }
+
+    public static OwnerStoreResponseDto from(Store store, double averageRating, Long reviewCount) {
+        return new OwnerStoreResponseDto(
+                store.getId(),
+                store.getName(),
+                averageRating,
+                reviewCount,
+                store.getStoreStatus().name(),
+                store.isDeleted(),
+                store.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/mini/delivery/domain/store/repository/StoreRepository.java
+++ b/src/main/java/mini/delivery/domain/store/repository/StoreRepository.java
@@ -4,6 +4,7 @@ import mini.delivery.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,4 +17,6 @@ public interface StoreRepository extends JpaRepository<Store, Long>, CustomStore
     Optional<Store> findByIdAndUserIdAndIsDeletedFalse(Long storeId, Long userId);
 
     boolean existsByUserIdAndIsDeletedFalse(Long userId);
+
+    List<Store> findAllByUserId(Long userId);
 }

--- a/src/main/java/mini/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/mini/delivery/domain/store/service/StoreService.java
@@ -102,13 +102,29 @@ public class StoreService {
     }
 
     @Transactional
-    public void closeStore(Long storeId, String email){
+    public void closeStore(Long storeId, String email) {
         User user = userRepository.findByEmailAndIsDeletedFalse(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Store store = storeRepository.findByIdAndUserIdAndIsDeletedFalse(storeId, user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
 
         store.deleteStore();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OwnerStoreResponseDto> allFindStore(String email) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        List<Store> stores = storeRepository.findAllByUserId(user.getId());
+
+        return stores.stream()
+                .map(store -> {
+                    double averageRating = reviewRepository.averageRatingByStoreId(store.getId());
+                    long reviewCount = reviewRepository.countByStoreId(store.getId());
+
+                    return OwnerStoreResponseDto.from(store, averageRating, reviewCount);
+                })
+                .toList();
     }
 
     private void validateStoreLimit(Long userId) {


### PR DESCRIPTION
- 사장(로그인 사용자) 기준 가게 다건 조회 API 추가
- ReviewRepository: 가게별 평균 평점·리뷰 수 집계 시 삭제되지 않은 리뷰만 포함하도록 JPQL 정리