### PR TITLE
refactor: 불필요한 static 메서드 제거 및 private 메서드명 변경

### DIFF
--- a/src/main/java/mini/delivery/domain/cart/dto/CartItemResponseDto.java
+++ b/src/main/java/mini/delivery/domain/cart/dto/CartItemResponseDto.java
@@ -3,8 +3,6 @@ package mini.delivery.domain.cart.dto;
 import lombok.Getter;
 import mini.delivery.domain.cart.entity.CartItem;
 
-import java.util.List;
-
 @Getter
 public class CartItemResponseDto {
 
@@ -33,9 +31,5 @@ public class CartItemResponseDto {
                 cartItem.getQuantity(),
                 totalPrice
         );
-    }
-
-    public static List<CartItemResponseDto> from(List<CartItemResponseDto> cartItemResponseDtoList) {
-        return cartItemResponseDtoList;
     }
 }

--- a/src/main/java/mini/delivery/domain/cart/service/CartService.java
+++ b/src/main/java/mini/delivery/domain/cart/service/CartService.java
@@ -112,13 +112,13 @@ public class CartService {
 
         List<CartItem> items = cartItemRepository.findAllByCartIdWithMenu(cart.getId());
 
-        List<CartItemResponseDto> cartItemResponseDtoList = calculateTotalPrices(items);
+        List<CartItemResponseDto> cartItemResponseDtoList = toCartItemResponses(items);
         int totalAmount = calculateTotalAmount(items);
 
         return CartResponseDto.from(cart, cartItemResponseDtoList, totalAmount);
     }
 
-    private List<CartItemResponseDto> calculateTotalPrices(List<CartItem> items) {
+    private List<CartItemResponseDto> toCartItemResponses(List<CartItem> items) {
         return items.stream()
                 .map(item -> {
                     Menu menu = item.getMenu();


### PR DESCRIPTION
- CartItemResponseDto의 사용되지 않는 static 메서드 제거
- CartService의 calculateTotalPrices → toCartItemResponses로 메서드명 변경