### PR TITLE
feat: 장바구니 동일 메뉴 추가 시 수량 증가하도록 변경

### DIFF
--- a/src/main/java/mini/delivery/domain/cart/entity/CartItem.java
+++ b/src/main/java/mini/delivery/domain/cart/entity/CartItem.java
@@ -41,4 +41,8 @@ public class CartItem extends BaseEntity {
     public void updateQuantity(int quantity) {
         this.quantity = quantity;
     }
+
+    public void increaseQuantity(int quantity) {
+        this.quantity += quantity;
+    }
 }

--- a/src/main/java/mini/delivery/domain/cart/service/CartService.java
+++ b/src/main/java/mini/delivery/domain/cart/service/CartService.java
@@ -31,8 +31,8 @@ public class CartService {
     /**
      * 1. 장바구니를 조회하고 없으면 생성 (orElseGet)
      * 2. 다른 가게 메뉴를 담을 경우, 장바구니에 담긴 기존 메뉴 삭제 (가게 비교)
-     * 3. 동일한 메뉴 추가 불가
-     * 4. CartItem 저장
+     * 3. 동일한 메뉴 추가 시 수량 Update
+     * 4. 새 메뉴 추가 시 Insert
      */
     @Transactional
     public void addCartItem(Long menuId, int quantity, String email) {
@@ -47,10 +47,12 @@ public class CartService {
                 .orElseGet(() -> cartRepository.save(Cart.create(user, menu.getStore())));
 
         clearCartIfDifferentStore(cart, menu.getStore());
-        validateDuplicateMenu(cart, menuId);
 
-        CartItem cartItem = CartItem.create(cart, menu, quantity);
-        cartItemRepository.save(cartItem);
+        cartItemRepository.findByCartAndMenuId(cart, menuId)
+                .ifPresentOrElse(
+                        item -> item.increaseQuantity(quantity),
+                        () -> cartItemRepository.save(CartItem.create(cart, menu, quantity))
+                );
     }
 
     @Transactional
@@ -97,13 +99,6 @@ public class CartService {
             cartItemRepository.deleteAllByCart(cart);
             cart.updateCart(newStore);
         }
-    }
-
-    private void validateDuplicateMenu(Cart cart, Long menuId) {
-        cartItemRepository.findByCartAndMenuId(cart, menuId)
-                .ifPresent(item -> {
-                    throw new CustomException(ErrorCode.CART_ITEM_ALREADY_EXISTS);
-                });
     }
 
     private CartResponseDto buildCartResponse(Long userId) {


### PR DESCRIPTION
## 기존
- 동일한 메뉴 추가 시 409 반환
- 수량 변경은 별도의 수량 변경 API 이용

## 개선
- 동일한 메뉴 추가 시 요청한 수량만큼 기존 항목의 수량이 증가하도록 변경 (Update)
- 새 메뉴 추가 시 장바구니에 항목을 생성 (Insert)